### PR TITLE
Fix bug deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ FAC_IMG_BASE_TAG ?= $(shell cat ./images/.env | grep FAC_IMG_BASE_TAG= | sed s/F
 FAC_IMG_EPICS_TAG ?= $(shell cat ./images/.env | grep FAC_IMG_EPICS_TAG= | sed s/FAC_IMG_EPICS_TAG=//g)
 FAC_IMG_APPS_TAG ?= $(shell cat ./images/.env | grep FAC_IMG_APPS_TAG= | sed s/FAC_IMG_APPS_TAG=//g)
 FAC_IMG_IOCS_TAG ?= $(shell cat ./images/.env | grep FAC_IMG_IOCS_TAG= | sed s/FAC_IMG_IOCS_TAG=//g)
-FAC_IMG_DEPLOY_TAG = ?= $(FAC_IMG_IOCS_TAG)
+FAC_IMG_DEPLOY_TAG ?= $(FAC_IMG_IOCS_TAG)
 
 # --- deploy ---
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ tag-template-fac-iocs:
 image-build-fac-deploy: image-cleanup
 	cd images; \
 	docker-compose --file docker-compose.yml build --force-rm --no-cache fac-apps; \
-	docker push dockerregistry.lnls-sirius.com.br/fac/fac-apps:$(FAC_IMG_DEPLOY_TAG)
+	docker push dockerregistry.lnls-sirius.com.br/fac/fac-apps:$(FAC_IMG_DEPLOY_TAG); \
 	docker-compose --file docker-compose.yml build --force-rm --no-cache fac-apps; \
 	docker push dockerregistry.lnls-sirius.com.br/fac/fac-iocs:$(FAC_IMG_DEPLOY_TAG)
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ image-build-fac-deploy: image-cleanup
 	cd images; \
 	docker-compose --file docker-compose.yml build --force-rm --no-cache fac-apps; \
 	docker push dockerregistry.lnls-sirius.com.br/fac/fac-apps:$(FAC_IMG_DEPLOY_TAG); \
-	docker-compose --file docker-compose.yml build --force-rm --no-cache fac-apps; \
+	docker-compose --file docker-compose.yml build --force-rm --no-cache fac-iocs; \
 	docker push dockerregistry.lnls-sirius.com.br/fac/fac-iocs:$(FAC_IMG_DEPLOY_TAG)
 
 image-build-fac-iocs: image-cleanup image-pull-fac-apps


### PR DESCRIPTION
Note: comit https://github.com/lnls-sirius/docker-machine-applications/commit/b64e8fa9d4f68c65781af523d298adb7d9f11db0 was merged and pushed by mistake onto master, instead of onto a PR branch. Although protection rule was already in place, github now by default overrides this rule if commit is pushed by administrators! changed the settings of the repo to avoid this behaviour...