### PR TITLE
Add EPU50 IOC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 deploy-files/
+.vscode/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -232,11 +232,11 @@ service-start-si-ap-fofb:
 	docker stack deploy -c docker-stack-si-ap-fofb.yml facs-si-ap-fofb; \
 	sed -i "s/fac-iocs:.*/fac-iocs:__FAC_IOC_TAG_TEMPLATE__/g" docker-stack-si-ap-fofb.yml
 
-service-start-si-id-conv:
+service-start-si-id:
 	cd services; \
-	sed -i "s/fac-iocs:.*/fac-iocs:$(IMG_IOCS_TAG)/g" docker-stack-si-id-conv.yml; \
-	docker stack deploy -c docker-stack-si-id-conv.yml facs-si-id-conv; \
-	sed -i "s/fac-iocs:.*/fac-iocs:__FAC_IOC_TAG_TEMPLATE__/g" docker-stack-si-id-conv.yml
+	sed -i "s/fac-iocs:.*/fac-iocs:$(IMG_IOCS_TAG)/g" docker-stack-si-id.yml; \
+	docker stack deploy -c docker-stack-si-id.yml facs-si-id; \
+	sed -i "s/fac-iocs:.*/fac-iocs:__FAC_IOC_TAG_TEMPLATE__/g" docker-stack-si-id.yml
 
 service-start-as-ap-machshift:
 	cd services; \
@@ -318,9 +318,9 @@ service-stop-si-ap-fofb:
 	cd services; \
 	docker stack rm facs-si-ap-fofb
 
-service-stop-si-id-conv:
+service-stop-si-id:
 	cd services; \
-	docker stack rm facs-si-id-conv
+	docker stack rm facs-si-id
 
 service-stop-as-ap-machshift:
 	cd services; \
@@ -355,7 +355,7 @@ service-start-all:
 	docker stack deploy -c docker-stack-as-ap-diag.yml facs-as-ap-diag; \
 	docker stack deploy -c docker-stack-li-ap-energy.yml facs-li-ap-energy; \
 	docker stack deploy -c docker-stack-si-ap-fofb.yml facs-si-ap-fofb; \
-	docker stack deploy -c docker-stack-si-id-conv.yml facs-si-id-conv; \
+	docker stack deploy -c docker-stack-si-id.yml facs-si-id; \
 	docker stack deploy -c docker-stack-as-ap-machshift.yml facs-as-ap-machshift; \
 	docker stack deploy -c docker-stack-as-ap-injctrl.yml facs-as-ap-injctrl; \
 	sed -i "s/fac-iocs-li-ps:.*/fac-iocs-li-ps:__FAC_IOC_LI_PS_TAG_TEMPLATE__/g" docker-stack-li-ps.yml && \
@@ -381,6 +381,6 @@ service-stop-all:
 	docker stack rm facs-as-ap-diag; \
 	docker stack rm facs-li-ap-energy; \
 	docker stack rm facs-si-ap-fofb; \
-	docker stack rm facs-si-id-conv; \
+	docker stack rm facs-si-id; \
 	docker stack rm facs-as-ap-machshift; \
 	docker stack rm facs-as-ap-injctrl

--- a/apps/si-id-epu50.bash
+++ b/apps/si-id-epu50.bash
@@ -5,7 +5,7 @@ export PYTHONUNBUFFERED=yes
 # CPU usage estimate (ps aux):
 
 /usr/local/bin/sirius-ioc-si-id-epu50.py \
-    --pv-prefix SI-10SB:ID-EPU50:
+    --pv-prefix SI-10SB:ID-EPU50: \
 | tee /ioc-logs/sirius-ioc-si-id-epu50.log &
 
 # run cron for log rotation

--- a/apps/si-id-epu50.bash
+++ b/apps/si-id-epu50.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+export PYTHONUNBUFFERED=yes
+
+# CPU usage estimate (ps aux):
+
+/usr/local/bin/sirius-ioc-si-id-epu50.py \
+| tee /ioc-logs/sirius-ioc-si-id-epu50.log & 
+
+# run cron for log rotation
+cron &
+
+# keep entry point running
+sleep infinity

--- a/apps/si-id-epu50.bash
+++ b/apps/si-id-epu50.bash
@@ -5,12 +5,7 @@ export PYTHONUNBUFFERED=yes
 # CPU usage estimate (ps aux):
 
 /usr/local/bin/sirius-ioc-si-id-epu50.py \
-    --pv-prefix SI-10SB:ID-EPU50: \
-    --drive-io-port 5050 \
-    --drive-msg-port 5052 \
-    --beaglebone-addr 10.128.110.160 \
-    --autosave-dir /ioc-logs/autosave \
-    --request-file /ioc-logs/source/autosave_epu.req \
+    --pv-prefix SI-10SB:ID-EPU50:
 | tee /ioc-logs/sirius-ioc-si-id-epu50.log &
 
 # run cron for log rotation

--- a/apps/si-id-epu50.bash
+++ b/apps/si-id-epu50.bash
@@ -5,7 +5,7 @@ export PYTHONUNBUFFERED=yes
 # CPU usage estimate (ps aux):
 
 /usr/local/bin/sirius-ioc-si-id-epu50.py \
-| tee /ioc-logs/sirius-ioc-si-id-epu50.log & 
+| tee /ioc-logs/sirius-ioc-si-id-epu50.log &
 
 # run cron for log rotation
 cron &

--- a/apps/si-id-epu50.bash
+++ b/apps/si-id-epu50.bash
@@ -5,6 +5,12 @@ export PYTHONUNBUFFERED=yes
 # CPU usage estimate (ps aux):
 
 /usr/local/bin/sirius-ioc-si-id-epu50.py \
+    --pv-prefix SI-10SB:ID-EPU50: \
+    --drive-io-port 5050 \
+    --drive-msg-port 5052 \
+    --beaglebone-addr 10.128.110.160 \
+    --autosave-dir /ioc-logs/autosave \
+    --request-file /ioc-logs/source/autosave_epu.req \
 | tee /ioc-logs/sirius-ioc-si-id-epu50.log &
 
 # run cron for log rotation

--- a/dockerfile-templates/Dockerfile.deps
+++ b/dockerfile-templates/Dockerfile.deps
@@ -34,4 +34,5 @@ RUN pip-sirius install \
     scipy \
     pydantic \
     pyaml \
+    serial \
     toml

--- a/dockerfile-templates/Dockerfile.deps
+++ b/dockerfile-templates/Dockerfile.deps
@@ -31,4 +31,7 @@ RUN pip-sirius install \
     pyvisa \
     pyvisa_py \
     urllib3 \
-    scipy
+    scipy \
+    pydantic \
+    pyaml \
+    toml

--- a/dockerfile-templates/Dockerfile.deps
+++ b/dockerfile-templates/Dockerfile.deps
@@ -33,6 +33,6 @@ RUN pip-sirius install \
     urllib3 \
     scipy \
     pydantic \
-    pyaml \
+    pyyaml \
     serial \
     toml

--- a/dockerfile-templates/Dockerfile.python
+++ b/dockerfile-templates/Dockerfile.python
@@ -10,10 +10,10 @@ ENV TZ America/Sao_Paulo
 
 # Configure apt proxy
 
-ARG APT_PROXY_SERVER=10.0.38.42:3142
-RUN \
-    echo "Acquire::http { Proxy \"http://${APT_PROXY_SERVER}\"; }" > /etc/apt/apt.conf.d/proxy ;\
-    echo "Acquire::https::proxy \"DIRECT\";" >> /etc/apt/apt.conf.d/proxy
+# ARG APT_PROXY_SERVER=10.0.38.42:3142
+# RUN \
+#    echo "Acquire::http { Proxy \"http://${APT_PROXY_SERVER}\"; }" > /etc/apt/apt.conf.d/proxy ;\
+#    echo "Acquire::https::proxy \"DIRECT\";" >> /etc/apt/apt.conf.d/proxy
 
 # Install generic apt packages
 

--- a/dockerfile-templates/Dockerfile.python2
+++ b/dockerfile-templates/Dockerfile.python2
@@ -10,10 +10,10 @@ ENV TZ America/Sao_Paulo
 
 # Configure apt proxy
 
-ARG APT_PROXY_SERVER=10.0.38.42:3142
-RUN \
-    echo "Acquire::http { Proxy \"http://${APT_PROXY_SERVER}\"; }" > /etc/apt/apt.conf.d/proxy ;\
-    echo "Acquire::https::proxy \"DIRECT\";" >> /etc/apt/apt.conf.d/proxy
+# ARG APT_PROXY_SERVER=10.0.38.42:3142
+# RUN \
+#     echo "Acquire::http { Proxy \"http://${APT_PROXY_SERVER}\"; }" > /etc/apt/apt.conf.d/proxy ;\
+#     echo "Acquire::https::proxy \"DIRECT\";" >> /etc/apt/apt.conf.d/proxy
 
 # Install generic apt packages
 

--- a/services/docker-stack-si-id-epu50.yml
+++ b/services/docker-stack-si-id-epu50.yml
@@ -1,0 +1,28 @@
+version: "3.7"
+
+services:
+
+  iocs:
+    image: dockerregistry.lnls-sirius.com.br/fac/fac-iocs:__FAC_IOC_TAG_TEMPLATE__
+    command: bash -c '/ioc-apps/si-id-epu50.bash'
+    volumes:
+      - "/storage/common/fac/iocs-log:/home/sirius/iocs-log"
+    deploy:
+      placement:
+        constraints:
+          - node.hostname == IA-18RaDiag04-CO-IOCSrv
+      replicas: 1
+      restart_policy:
+        condition: any
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "10"
+        max-size: "10m"
+    networks:
+      - ioc-network
+
+networks:
+  ioc-network:
+    external: true
+    name: "host"

--- a/services/docker-stack-si-id.yml
+++ b/services/docker-stack-si-id.yml
@@ -1,0 +1,50 @@
+version: "3.7"
+
+services:
+
+  epu50:
+    image: dockerregistry.lnls-sirius.com.br/fac/fac-iocs:__FAC_IOC_TAG_TEMPLATE__
+    command: bash -c '/ioc-apps/si-id-epu50.bash'
+    volumes:
+      - "/storage/common/fac/iocs-log:/home/sirius/iocs-log"
+    deploy:
+      placement:
+        constraints:
+          - node.hostname == IA-18RaDiag04-CO-IOCSrv
+      replicas: 1
+      restart_policy:
+        condition: any
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "10"
+        max-size: "10m"
+    networks:
+      - ioc-network
+
+  conv:
+    image: dockerregistry.lnls-sirius.com.br/fac/fac-iocs:__FAC_IOC_TAG_TEMPLATE__
+    depends_on:
+      - "epu50"
+    command: bash -c '/ioc-apps/si-id-conv.bash'
+    volumes:
+      - "/storage/common/fac/iocs-log:/home/sirius/iocs-log"
+    deploy:
+      placement:
+        constraints:
+          - node.hostname == IA-18RaDiag04-CO-IOCSrv
+      replicas: 1
+      restart_policy:
+        condition: any
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "10"
+        max-size: "10m"
+    networks:
+      - ioc-network
+
+networks:
+  ioc-network:
+    external: true
+    name: "host"

--- a/tags.mk
+++ b/tags.mk
@@ -10,11 +10,11 @@ EPICS_BASE_TAG ?= base-3.15.6
 
 # tags used for creating docker images
 IMG_DEBIAN_TAG ?= bullseye-20211011
-DEPLOY_TAG ?= 2022-02-04
+DEPLOY_TAG ?= 2022-12-03
 
 # image tags used for starting docker services
-IMG_IOCS_LI_PS_TAG ?= 2021-11-29
-IMG_PYTHON_TAG ?= 2022-02-04 # also used as base image for fac-epics
-IMG_EPICS_TAG ?= 2022-02-04
-IMG_DEPS_TAG ?= 2022-02-04
+IMG_IOCS_LI_PS_TAG ?= 2022-12-03
+IMG_PYTHON_TAG ?= 2022-12-03 # also used as base image for fac-epics
+IMG_EPICS_TAG ?= 2022-12-03
+IMG_DEPS_TAG ?= 2022-12-03
 IMG_IOCS_TAG ?= $(DEPLOY_TAG)

--- a/tags.mk
+++ b/tags.mk
@@ -1,5 +1,5 @@
 # tag for lnls-ansible repo from which package versions are to be taken
-LNLS_ANSIBLE_TAG ?= master
+LNLS_ANSIBLE_TAG ?= add-epu-ioc
 VERSION_FILE ?= https://raw.githubusercontent.com/lnls-sirius/lnls-ansible/$(LNLS_ANSIBLE_TAG)/inventories/sirius/group_vars/all
 
 # Local file server URL
@@ -10,7 +10,7 @@ EPICS_BASE_TAG ?= base-3.15.6
 
 # tags used for creating docker images
 IMG_DEBIAN_TAG ?= bullseye-20211011
-DEPLOY_TAG ?= 2022-12-03
+DEPLOY_TAG ?= test-add-epu50
 
 # image tags used for starting docker services
 IMG_IOCS_LI_PS_TAG ?= 2022-12-03

--- a/tags.mk
+++ b/tags.mk
@@ -1,5 +1,5 @@
 # tag for lnls-ansible repo from which package versions are to be taken
-LNLS_ANSIBLE_TAG ?= add-epu-ioc
+LNLS_ANSIBLE_TAG ?= master
 VERSION_FILE ?= https://raw.githubusercontent.com/lnls-sirius/lnls-ansible/$(LNLS_ANSIBLE_TAG)/inventories/sirius/group_vars/all
 
 # Local file server URL
@@ -10,11 +10,11 @@ EPICS_BASE_TAG ?= base-3.15.6
 
 # tags used for creating docker images
 IMG_DEBIAN_TAG ?= bullseye-20211011
-DEPLOY_TAG ?= test-add-epu50
+DEPLOY_TAG ?= 2022-02-04
 
 # image tags used for starting docker services
 IMG_IOCS_LI_PS_TAG ?= 2022-12-03
 IMG_PYTHON_TAG ?= 2022-12-03 # also used as base image for fac-epics
 IMG_EPICS_TAG ?= 2022-12-03
-IMG_DEPS_TAG ?= 2022-12-03
+IMG_DEPS_TAG ?= 2022-12-12
 IMG_IOCS_TAG ?= $(DEPLOY_TAG)

--- a/tools/generate_service_files.py
+++ b/tools/generate_service_files.py
@@ -81,6 +81,7 @@ class ServiceConfig:
         'ts-ps-corrs': 'IA-20RaDiag02-CO-IOCSrv-2',
         'si-ap-fofb': 'IA-18RaDiag04-CO-IOCSrv',
         'si-id-conv': 'IA-18RaDiag04-CO-IOCSrv',
+        'si-id-epu50': 'IA-18RaDiag04-CO-IOCSrv',
         'si-ap-sofb': 'IA-20RaDiag01-CO-IOCSrv-2',
         'si-ps-dips': 'IA-14RaDiag03-CO-IOCSrv',
         'si-ps-quads-qfq': 'IA-16RaBbB-CO-IOCSrv',
@@ -348,6 +349,10 @@ class ServiceConfig:
             'trims-qs-m12-ia19': ('si-ps-trims-qs-m12-ia19', ('dips', 'quads-qd', 'quads-qfq')),
             'trims-qs-m12-ia20': ('si-ps-trims-qs-m12-ia20', ('dips', 'quads-qd', 'quads-qfq')),
             },
+        'si-id': {
+            'epu50': 'si-id-epu50',
+            'conv': ('si-id-conv', ('epu50', )),
+        },
         'it-ps': {
             'lens': 'it-ps-lens',
             },
@@ -609,6 +614,11 @@ def generate_service_2_ioc_table():
                                 prefixes.append(psn + ':' + strg)
                             except ValueError:
                                 pass
+                elif 'id' in ioc:
+                    iddev = ioc.split('-')[2].upper()
+                    idnames = IDSearch.get_idnames({'dev': iddev})
+                    # needs conversion to str to avoid SiriusPVName __str__
+                    prefixes.extend([str(idname) for idname in idnames])
                 elif 'diag' in prs[2]:
                     if prs[0] == 'li':
                         devs = LIDiagConst.ALL_DEVICES


### PR DESCRIPTION
- Added container to EPU50 IOC. This container uses the same IOC docker image that all other pcaspy IOCs use.
- Stacked this container under `si-id-conv` container (should we keep this conv service?)
- Commented out Apt proxy usage