### PR TITLE
Add label to services for Portainer access control

### DIFF
--- a/services/docker-stack-as-ap-currinfo.yml
+++ b/services/docker-stack-as-ap-currinfo.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ap-diag.yml
+++ b/services/docker-stack-as-ap-diag.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ap-injctrl.yml
+++ b/services/docker-stack-as-ap-injctrl.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ap-machshift.yml
+++ b/services/docker-stack-as-ap-machshift.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ap-opticscorr.yml
+++ b/services/docker-stack-as-ap-opticscorr.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ap-posang.yml
+++ b/services/docker-stack-as-ap-posang.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ap-sofb.yml
+++ b/services/docker-stack-as-ap-sofb.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia01.yml
+++ b/services/docker-stack-as-ps-dclinks-ia01.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia02.yml
+++ b/services/docker-stack-as-ps-dclinks-ia02.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia03.yml
+++ b/services/docker-stack-as-ps-dclinks-ia03.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia04.yml
+++ b/services/docker-stack-as-ps-dclinks-ia04.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia05.yml
+++ b/services/docker-stack-as-ps-dclinks-ia05.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia06.yml
+++ b/services/docker-stack-as-ps-dclinks-ia06.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia07.yml
+++ b/services/docker-stack-as-ps-dclinks-ia07.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia08.yml
+++ b/services/docker-stack-as-ps-dclinks-ia08.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia09.yml
+++ b/services/docker-stack-as-ps-dclinks-ia09.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia10.yml
+++ b/services/docker-stack-as-ps-dclinks-ia10.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia11.yml
+++ b/services/docker-stack-as-ps-dclinks-ia11.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia12.yml
+++ b/services/docker-stack-as-ps-dclinks-ia12.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia13.yml
+++ b/services/docker-stack-as-ps-dclinks-ia13.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia14.yml
+++ b/services/docker-stack-as-ps-dclinks-ia14.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia15.yml
+++ b/services/docker-stack-as-ps-dclinks-ia15.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia16.yml
+++ b/services/docker-stack-as-ps-dclinks-ia16.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia17.yml
+++ b/services/docker-stack-as-ps-dclinks-ia17.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia18.yml
+++ b/services/docker-stack-as-ps-dclinks-ia18.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia19.yml
+++ b/services/docker-stack-as-ps-dclinks-ia19.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia20.yml
+++ b/services/docker-stack-as-ps-dclinks-ia20.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-tbts-bodip.yml
+++ b/services/docker-stack-as-ps-dclinks-tbts-bodip.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks.yml
+++ b/services/docker-stack-as-ps-dclinks.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -34,6 +36,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -54,6 +58,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -74,6 +80,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -94,6 +102,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -114,6 +124,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -134,6 +146,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -154,6 +168,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -174,6 +190,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -194,6 +212,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -214,6 +234,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -234,6 +256,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -254,6 +278,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -274,6 +300,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -294,6 +322,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -314,6 +344,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -334,6 +366,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -354,6 +388,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -374,6 +410,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -394,6 +432,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -414,6 +454,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-pu-conv.yml
+++ b/services/docker-stack-as-pu-conv.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ti-general.yml
+++ b/services/docker-stack-as-ti-general.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ti.yml
+++ b/services/docker-stack-as-ti.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -34,6 +36,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -54,6 +58,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -74,6 +80,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -94,6 +102,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -114,6 +124,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -134,6 +146,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -154,6 +168,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -174,6 +190,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -194,6 +212,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-ba-ti-general.yml
+++ b/services/docker-stack-ba-ti-general.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bl-ap-imgproc.yml
+++ b/services/docker-stack-bl-ap-imgproc.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia01.yml
+++ b/services/docker-stack-bo-ps-corrs-ia01.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia02.yml
+++ b/services/docker-stack-bo-ps-corrs-ia02.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia04.yml
+++ b/services/docker-stack-bo-ps-corrs-ia04.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia05.yml
+++ b/services/docker-stack-bo-ps-corrs-ia05.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia07.yml
+++ b/services/docker-stack-bo-ps-corrs-ia07.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia08.yml
+++ b/services/docker-stack-bo-ps-corrs-ia08.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia10.yml
+++ b/services/docker-stack-bo-ps-corrs-ia10.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia11.yml
+++ b/services/docker-stack-bo-ps-corrs-ia11.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia13.yml
+++ b/services/docker-stack-bo-ps-corrs-ia13.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia14.yml
+++ b/services/docker-stack-bo-ps-corrs-ia14.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia16.yml
+++ b/services/docker-stack-bo-ps-corrs-ia16.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia17.yml
+++ b/services/docker-stack-bo-ps-corrs-ia17.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia20.yml
+++ b/services/docker-stack-bo-ps-corrs-ia20.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs.yml
+++ b/services/docker-stack-bo-ps-corrs.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -34,6 +36,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -54,6 +58,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -74,6 +80,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -94,6 +102,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -114,6 +124,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -134,6 +146,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -154,6 +168,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -174,6 +190,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -194,6 +212,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -214,6 +234,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -234,6 +256,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -254,6 +278,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-dips.yml
+++ b/services/docker-stack-bo-ps-dips.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-fams.yml
+++ b/services/docker-stack-bo-ps-fams.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -36,6 +38,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -58,6 +62,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-quads.yml
+++ b/services/docker-stack-bo-ps-quads.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-sexts.yml
+++ b/services/docker-stack-bo-ps-sexts.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps.yml
+++ b/services/docker-stack-bo-ps.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -36,6 +38,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -58,6 +62,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -80,6 +86,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -102,6 +110,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -124,6 +134,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -146,6 +158,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -168,6 +182,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -190,6 +206,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -212,6 +230,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -234,6 +254,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -256,6 +278,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -278,6 +302,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -300,6 +326,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -322,6 +350,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -344,6 +374,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ti-bpms-corrs.yml
+++ b/services/docker-stack-bo-ti-bpms-corrs.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ti-general.yml
+++ b/services/docker-stack-bo-ti-general.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-it-ps-lens.yml
+++ b/services/docker-stack-it-ps-lens.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-it-ps.yml
+++ b/services/docker-stack-it-ps.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ap-energy.yml
+++ b/services/docker-stack-li-ap-energy.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ps-conv.yml
+++ b/services/docker-stack-li-ps-conv.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ps-corrs.yml
+++ b/services/docker-stack-li-ps-corrs.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ps-diag.yml
+++ b/services/docker-stack-li-ps-diag.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ps-slnds.yml
+++ b/services/docker-stack-li-ps-slnds.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ps-spect-quads-lens.yml
+++ b/services/docker-stack-li-ps-spect-quads-lens.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ps.yml
+++ b/services/docker-stack-li-ps.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -34,6 +36,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -54,6 +58,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -78,6 +84,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -102,6 +110,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ti-general.yml
+++ b/services/docker-stack-li-ti-general.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-fofb.yml
+++ b/services/docker-stack-si-ap-fofb.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-idff-delta52.yml
+++ b/services/docker-stack-si-ap-idff-delta52.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-idff-ivu18-sb08.yml
+++ b/services/docker-stack-si-ap-idff-ivu18-sb08.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-idff-ivu18-sb14.yml
+++ b/services/docker-stack-si-ap-idff-ivu18-sb14.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-idff.yml
+++ b/services/docker-stack-si-ap-idff.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -34,6 +36,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -54,6 +58,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-orbintlk.yml
+++ b/services/docker-stack-si-ap-orbintlk.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-sofb.yml
+++ b/services/docker-stack-si-ap-sofb.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-stabinfo.yml
+++ b/services/docker-stack-si-ap-stabinfo.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-di-fpmosc.yml
+++ b/services/docker-stack-si-di-fpmosc.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-id-conv.yml
+++ b/services/docker-stack-si-id-conv.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-id.yml
+++ b/services/docker-stack-si-id.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia01.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia01.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia02.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia02.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia03.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia03.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia04.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia04.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia05.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia05.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia06.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia06.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia07.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia07.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia08.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia08.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia09.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia09.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia10.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia10.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia11.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia11.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia12.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia12.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia13.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia13.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia14.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia14.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia15.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia15.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia16.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia16.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia17.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia17.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia18.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia18.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia19.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia19.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-conv-fastcorrs-ia20.yml
+++ b/services/docker-stack-si-ps-conv-fastcorrs-ia20.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrlong-sb-ia08.yml
+++ b/services/docker-stack-si-ps-corrlong-sb-ia08.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrlong-sb-ia14.yml
+++ b/services/docker-stack-si-ps-corrlong-sb-ia14.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia01.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia01.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia02.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia02.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia03.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia03.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia04.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia04.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia05.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia05.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia06.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia06.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia07.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia07.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia08.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia08.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia09.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia09.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia10.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia10.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia11.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia11.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia12.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia12.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia13.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia13.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia14.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia14.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia15.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia15.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia16.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia16.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia17.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia17.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia18.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia18.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia19.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia19.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia20.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia20.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia01.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia01.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia02.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia02.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia03.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia03.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia04.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia04.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia05.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia05.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia06.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia06.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia07.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia07.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia08.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia08.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia09.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia09.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia10.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia10.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia11.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia11.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia12.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia12.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia13.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia13.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia14.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia14.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia15.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia15.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia16.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia16.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia17.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia17.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia18.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia18.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia19.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia19.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia20.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia20.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-qs-sb-ia10.yml
+++ b/services/docker-stack-si-ps-corrs-qs-sb-ia10.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-sb-ia06.yml
+++ b/services/docker-stack-si-ps-corrs-sb-ia06.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-sb-ia08.yml
+++ b/services/docker-stack-si-ps-corrs-sb-ia08.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-sb-ia14.yml
+++ b/services/docker-stack-si-ps-corrs-sb-ia14.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-diag-fastcorrs.yml
+++ b/services/docker-stack-si-ps-diag-fastcorrs.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-dips.yml
+++ b/services/docker-stack-si-ps-dips.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-fastcorrs.yml
+++ b/services/docker-stack-si-ps-fastcorrs.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -34,6 +36,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -54,6 +58,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -74,6 +80,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -94,6 +102,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -114,6 +124,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -134,6 +146,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -154,6 +168,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -174,6 +190,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -194,6 +212,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -214,6 +234,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -234,6 +256,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -254,6 +278,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -274,6 +300,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -294,6 +322,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -314,6 +344,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -334,6 +366,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -354,6 +388,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -374,6 +410,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -394,6 +432,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -414,6 +454,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-quads-qd.yml
+++ b/services/docker-stack-si-ps-quads-qd.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-quads-qfq.yml
+++ b/services/docker-stack-si-ps-quads-qfq.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-sexts-sda12b2-sfa0p0-sda0p0.yml
+++ b/services/docker-stack-si-ps-sexts-sda12b2-sfa0p0-sda0p0.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-sexts-sfa12-sda3p1-sfb0-sdb01.yml
+++ b/services/docker-stack-si-ps-sexts-sfa12-sda3p1-sfb0-sdb01.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-sexts-sfb12-sdb3-sfp12-sdp23.yml
+++ b/services/docker-stack-si-ps-sexts-sfb12-sdb3-sfp12-sdp23.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia01.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia01.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia02.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia02.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia03.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia03.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia04.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia04.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia05.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia05.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia06.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia06.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia07.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia07.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia08.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia08.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia09.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia09.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia10.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia10.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia11.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia11.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia12.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia12.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia13.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia13.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia14.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia14.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia15.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia15.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia16.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia16.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia17.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia17.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia18.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia18.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia19.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia19.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia20.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia20.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia01.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia01.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia02.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia02.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia03.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia03.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia04.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia04.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia05.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia05.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia06.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia06.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia07.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia07.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia08.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia08.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia09.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia09.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia10.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia10.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia11.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia11.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia12.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia12.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia13.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia13.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia14.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia14.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia15.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia15.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia16.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia16.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia17.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia17.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia18.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia18.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia19.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia19.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia20.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia20.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps.yml
+++ b/services/docker-stack-si-ps.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -36,6 +38,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -58,6 +62,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -80,6 +86,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -102,6 +110,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -124,6 +134,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -146,6 +158,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -168,6 +182,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -190,6 +206,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -212,6 +230,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -234,6 +254,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -256,6 +278,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -278,6 +302,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -300,6 +326,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -322,6 +350,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -344,6 +374,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -366,6 +398,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -388,6 +422,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -410,6 +446,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -432,6 +470,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -454,6 +494,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -476,6 +518,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -498,6 +542,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -520,6 +566,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -542,6 +590,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -564,6 +614,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -586,6 +638,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -608,6 +662,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -630,6 +686,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -652,6 +710,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -674,6 +734,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -696,6 +758,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -718,6 +782,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -740,6 +806,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -762,6 +830,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -784,6 +854,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -806,6 +878,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -828,6 +902,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -850,6 +926,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -872,6 +950,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -894,6 +974,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -916,6 +998,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -938,6 +1022,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -960,6 +1046,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -982,6 +1070,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1004,6 +1094,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1026,6 +1118,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1048,6 +1142,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1070,6 +1166,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1092,6 +1190,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1114,6 +1214,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1136,6 +1238,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1160,6 +1264,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1184,6 +1290,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1208,6 +1316,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1232,6 +1342,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1256,6 +1368,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1280,6 +1394,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1304,6 +1420,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1328,6 +1446,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1352,6 +1472,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1376,6 +1498,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1400,6 +1524,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1424,6 +1550,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1448,6 +1576,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1472,6 +1602,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1496,6 +1628,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1520,6 +1654,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1544,6 +1680,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1568,6 +1706,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1592,6 +1732,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1616,6 +1758,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1640,6 +1784,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1664,6 +1810,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1688,6 +1836,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1712,6 +1862,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1736,6 +1888,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1760,6 +1914,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1784,6 +1940,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1808,6 +1966,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1832,6 +1992,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1856,6 +2018,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1880,6 +2044,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1904,6 +2070,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1928,6 +2096,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1952,6 +2122,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -1976,6 +2148,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -2000,6 +2174,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -2024,6 +2200,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -2048,6 +2226,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -2072,6 +2252,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -2096,6 +2278,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ti-bpms-corrs.yml
+++ b/services/docker-stack-si-ti-bpms-corrs.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ti-general.yml
+++ b/services/docker-stack-si-ti-general.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ti-trims-skews.yml
+++ b/services/docker-stack-si-ti-trims-skews.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-tb-ps-corrs.yml
+++ b/services/docker-stack-tb-ps-corrs.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-tb-ps-dips.yml
+++ b/services/docker-stack-tb-ps-dips.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-tb-ps-quads.yml
+++ b/services/docker-stack-tb-ps-quads.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-tb-ps.yml
+++ b/services/docker-stack-tb-ps.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -36,6 +38,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -58,6 +62,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-tb-ti-general.yml
+++ b/services/docker-stack-tb-ti-general.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-ts-ps-corrs.yml
+++ b/services/docker-stack-ts-ps-corrs.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-ts-ps-dips.yml
+++ b/services/docker-stack-ts-ps-dips.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-ts-ps-quads.yml
+++ b/services/docker-stack-ts-ps-quads.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-ts-ps.yml
+++ b/services/docker-stack-ts-ps.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -36,6 +38,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:
@@ -58,6 +62,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-ts-ti-general.yml
+++ b/services/docker-stack-ts-ti-general.yml
@@ -14,6 +14,8 @@ services:
       replicas: 1
       restart_policy:
         condition: any
+      labels:
+        io.portainer.accesscontrol.public: ""
     logging:
       driver: "json-file"
       options:

--- a/tools/generate_service_files.py
+++ b/tools/generate_service_files.py
@@ -586,6 +586,8 @@ class DockerStackConfig(ServiceConfig):
         strf += '\n' + '      replicas: ' + self.replicas
         strf += '\n' + '      restart_policy:'
         strf += '\n' + '        condition: ' + self.condition
+        strf += '\n' + '      labels:'
+        strf += '\n' + '        io.portainer.accesscontrol.public: ""'
         strf += '\n' + '    logging:'
         strf += '\n' + '      driver: ' + '"' + self.driver + '"'
         strf += '\n' + '      options:'


### PR DESCRIPTION
This label allows non-admin users to restart the services on Portainer. Access to Portainer is granted to specific users and groups only, and with this change those users will not require admin privileges.