### PR TITLE
Add label for Docker container log forwarding

### DIFF
--- a/services/docker-stack-as-ap-currinfo.yml
+++ b/services/docker-stack-as-ap-currinfo.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ap-diag.yml
+++ b/services/docker-stack-as-ap-diag.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ap-injctrl.yml
+++ b/services/docker-stack-as-ap-injctrl.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ap-machshift.yml
+++ b/services/docker-stack-as-ap-machshift.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ap-opticscorr.yml
+++ b/services/docker-stack-as-ap-opticscorr.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ap-posang.yml
+++ b/services/docker-stack-as-ap-posang.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ap-sofb.yml
+++ b/services/docker-stack-as-ap-sofb.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia01.yml
+++ b/services/docker-stack-as-ps-dclinks-ia01.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia02.yml
+++ b/services/docker-stack-as-ps-dclinks-ia02.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia03.yml
+++ b/services/docker-stack-as-ps-dclinks-ia03.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia04.yml
+++ b/services/docker-stack-as-ps-dclinks-ia04.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia05.yml
+++ b/services/docker-stack-as-ps-dclinks-ia05.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia06.yml
+++ b/services/docker-stack-as-ps-dclinks-ia06.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia07.yml
+++ b/services/docker-stack-as-ps-dclinks-ia07.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia08.yml
+++ b/services/docker-stack-as-ps-dclinks-ia08.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia09.yml
+++ b/services/docker-stack-as-ps-dclinks-ia09.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia10.yml
+++ b/services/docker-stack-as-ps-dclinks-ia10.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia11.yml
+++ b/services/docker-stack-as-ps-dclinks-ia11.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia12.yml
+++ b/services/docker-stack-as-ps-dclinks-ia12.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia13.yml
+++ b/services/docker-stack-as-ps-dclinks-ia13.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia14.yml
+++ b/services/docker-stack-as-ps-dclinks-ia14.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia15.yml
+++ b/services/docker-stack-as-ps-dclinks-ia15.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia16.yml
+++ b/services/docker-stack-as-ps-dclinks-ia16.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia17.yml
+++ b/services/docker-stack-as-ps-dclinks-ia17.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia18.yml
+++ b/services/docker-stack-as-ps-dclinks-ia18.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia19.yml
+++ b/services/docker-stack-as-ps-dclinks-ia19.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-ia20.yml
+++ b/services/docker-stack-as-ps-dclinks-ia20.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks-tbts-bodip.yml
+++ b/services/docker-stack-as-ps-dclinks-tbts-bodip.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ps-dclinks.yml
+++ b/services/docker-stack-as-ps-dclinks.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -46,6 +48,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -72,6 +76,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -98,6 +104,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -124,6 +132,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -150,6 +160,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -176,6 +188,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -202,6 +216,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -228,6 +244,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -254,6 +272,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -280,6 +300,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -306,6 +328,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -332,6 +356,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -358,6 +384,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -384,6 +412,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -410,6 +440,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -436,6 +468,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -462,6 +496,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -488,6 +524,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -514,6 +552,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -540,6 +580,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-pu-conv.yml
+++ b/services/docker-stack-as-pu-conv.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ti-general.yml
+++ b/services/docker-stack-as-ti-general.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-as-ti.yml
+++ b/services/docker-stack-as-ti.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -46,6 +48,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -72,6 +76,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -98,6 +104,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -124,6 +132,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -150,6 +160,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -176,6 +188,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -202,6 +216,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -228,6 +244,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -254,6 +272,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-ba-ti-general.yml
+++ b/services/docker-stack-ba-ti-general.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bl-ap-imgproc.yml
+++ b/services/docker-stack-bl-ap-imgproc.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia01.yml
+++ b/services/docker-stack-bo-ps-corrs-ia01.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia02.yml
+++ b/services/docker-stack-bo-ps-corrs-ia02.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia04.yml
+++ b/services/docker-stack-bo-ps-corrs-ia04.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia05.yml
+++ b/services/docker-stack-bo-ps-corrs-ia05.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia07.yml
+++ b/services/docker-stack-bo-ps-corrs-ia07.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia08.yml
+++ b/services/docker-stack-bo-ps-corrs-ia08.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia10.yml
+++ b/services/docker-stack-bo-ps-corrs-ia10.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia11.yml
+++ b/services/docker-stack-bo-ps-corrs-ia11.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia13.yml
+++ b/services/docker-stack-bo-ps-corrs-ia13.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia14.yml
+++ b/services/docker-stack-bo-ps-corrs-ia14.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia16.yml
+++ b/services/docker-stack-bo-ps-corrs-ia16.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia17.yml
+++ b/services/docker-stack-bo-ps-corrs-ia17.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs-ia20.yml
+++ b/services/docker-stack-bo-ps-corrs-ia20.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-corrs.yml
+++ b/services/docker-stack-bo-ps-corrs.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -46,6 +48,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -72,6 +76,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -98,6 +104,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -124,6 +132,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -150,6 +160,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -176,6 +188,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -202,6 +216,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -228,6 +244,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -254,6 +272,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -280,6 +300,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -306,6 +328,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -332,6 +356,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-dips.yml
+++ b/services/docker-stack-bo-ps-dips.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-fams.yml
+++ b/services/docker-stack-bo-ps-fams.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -48,6 +50,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -76,6 +80,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-quads.yml
+++ b/services/docker-stack-bo-ps-quads.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps-sexts.yml
+++ b/services/docker-stack-bo-ps-sexts.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ps.yml
+++ b/services/docker-stack-bo-ps.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -48,6 +50,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -76,6 +80,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -104,6 +110,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -132,6 +140,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -160,6 +170,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -188,6 +200,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -216,6 +230,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -244,6 +260,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -272,6 +290,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -300,6 +320,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -328,6 +350,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -356,6 +380,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -384,6 +410,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -412,6 +440,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -440,6 +470,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ti-bpms-corrs.yml
+++ b/services/docker-stack-bo-ti-bpms-corrs.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-bo-ti-general.yml
+++ b/services/docker-stack-bo-ti-general.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-it-ps-lens.yml
+++ b/services/docker-stack-it-ps-lens.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-it-ps.yml
+++ b/services/docker-stack-it-ps.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ap-energy.yml
+++ b/services/docker-stack-li-ap-energy.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ps-conv.yml
+++ b/services/docker-stack-li-ps-conv.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ps-corrs.yml
+++ b/services/docker-stack-li-ps-corrs.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ps-diag.yml
+++ b/services/docker-stack-li-ps-diag.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ps-slnds.yml
+++ b/services/docker-stack-li-ps-slnds.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ps-spect-quads-lens.yml
+++ b/services/docker-stack-li-ps-spect-quads-lens.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ps.yml
+++ b/services/docker-stack-li-ps.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -46,6 +48,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -72,6 +76,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -102,6 +108,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -132,6 +140,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-li-ti-general.yml
+++ b/services/docker-stack-li-ti-general.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-fofb.yml
+++ b/services/docker-stack-si-ap-fofb.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-idff-delta52.yml
+++ b/services/docker-stack-si-ap-idff-delta52.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-idff.yml
+++ b/services/docker-stack-si-ap-idff.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-orbintlk.yml
+++ b/services/docker-stack-si-ap-orbintlk.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-sofb.yml
+++ b/services/docker-stack-si-ap-sofb.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ap-stabinfo.yml
+++ b/services/docker-stack-si-ap-stabinfo.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-di-fpmosc.yml
+++ b/services/docker-stack-si-di-fpmosc.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-id-conv.yml
+++ b/services/docker-stack-si-id-conv.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-id.yml
+++ b/services/docker-stack-si-id.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrlong-sb-ia08.yml
+++ b/services/docker-stack-si-ps-corrlong-sb-ia08.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrlong-sb-ia14.yml
+++ b/services/docker-stack-si-ps-corrlong-sb-ia14.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrlong-sp-ia11.yml
+++ b/services/docker-stack-si-ps-corrlong-sp-ia11.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia01.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia01.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia02.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia02.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia03.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia03.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia04.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia04.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia05.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia05.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia06.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia06.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia07.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia07.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia08.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia08.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia09.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia09.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia10.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia10.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia11.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia11.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia12.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia12.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia13.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia13.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia14.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia14.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia15.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia15.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia16.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia16.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia17.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia17.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia18.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia18.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia19.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia19.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c134-ia20.yml
+++ b/services/docker-stack-si-ps-corrs-c134-ia20.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia01.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia01.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia02.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia02.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia03.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia03.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia04.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia04.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia05.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia05.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia06.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia06.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia07.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia07.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia08.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia08.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia09.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia09.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia10.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia10.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia11.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia11.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia12.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia12.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia13.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia13.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia14.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia14.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia15.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia15.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia16.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia16.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia17.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia17.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia18.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia18.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia19.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia19.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-c2m12-ia20.yml
+++ b/services/docker-stack-si-ps-corrs-c2m12-ia20.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-qs-sb-ia10.yml
+++ b/services/docker-stack-si-ps-corrs-qs-sb-ia10.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-sb-ia06.yml
+++ b/services/docker-stack-si-ps-corrs-sb-ia06.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-sb-ia08.yml
+++ b/services/docker-stack-si-ps-corrs-sb-ia08.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-sb-ia14.yml
+++ b/services/docker-stack-si-ps-corrs-sb-ia14.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-sp-ia07.yml
+++ b/services/docker-stack-si-ps-corrs-sp-ia07.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-corrs-sp-ia11.yml
+++ b/services/docker-stack-si-ps-corrs-sp-ia11.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-diag-fastcorrs.yml
+++ b/services/docker-stack-si-ps-diag-fastcorrs.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-dips.yml
+++ b/services/docker-stack-si-ps-dips.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-fastcorrs.yml
+++ b/services/docker-stack-si-ps-fastcorrs.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-qs-sp-ia11.yml
+++ b/services/docker-stack-si-ps-qs-sp-ia11.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-quads-qd.yml
+++ b/services/docker-stack-si-ps-quads-qd.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-quads-qfq.yml
+++ b/services/docker-stack-si-ps-quads-qfq.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-sexts-sda12b2-sfa0p0-sda0p0.yml
+++ b/services/docker-stack-si-ps-sexts-sda12b2-sfa0p0-sda0p0.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-sexts-sfa12-sda3p1-sfb0-sdb01.yml
+++ b/services/docker-stack-si-ps-sexts-sfa12-sda3p1-sfb0-sdb01.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-sexts-sfb12-sdb3-sfp12-sdp23.yml
+++ b/services/docker-stack-si-ps-sexts-sfb12-sdb3-sfp12-sdp23.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia01.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia01.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia02.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia02.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia03.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia03.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia04.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia04.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia05.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia05.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia06.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia06.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia07.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia07.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia08.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia08.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia09.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia09.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia10.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia10.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia11.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia11.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia12.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia12.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia13.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia13.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia14.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia14.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia15.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia15.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia16.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia16.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia17.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia17.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia18.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia18.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia19.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia19.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-c1234-ia20.yml
+++ b/services/docker-stack-si-ps-trims-qs-c1234-ia20.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia01.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia01.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia02.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia02.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia03.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia03.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia04.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia04.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia05.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia05.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia06.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia06.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia07.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia07.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia08.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia08.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia09.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia09.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia10.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia10.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia11.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia11.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia12.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia12.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia13.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia13.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia14.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia14.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia15.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia15.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia16.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia16.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia17.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia17.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia18.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia18.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia19.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia19.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps-trims-qs-m12-ia20.yml
+++ b/services/docker-stack-si-ps-trims-qs-m12-ia20.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ps.yml
+++ b/services/docker-stack-si-ps.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -48,6 +50,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -76,6 +80,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -104,6 +110,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -132,6 +140,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -160,6 +170,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -188,6 +200,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -216,6 +230,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -244,6 +260,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -272,6 +290,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -300,6 +320,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -328,6 +350,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -356,6 +380,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -384,6 +410,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -412,6 +440,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -440,6 +470,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -468,6 +500,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -496,6 +530,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -524,6 +560,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -552,6 +590,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -580,6 +620,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -608,6 +650,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -636,6 +680,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -664,6 +710,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -692,6 +740,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -720,6 +770,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -748,6 +800,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -776,6 +830,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -804,6 +860,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -832,6 +890,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -860,6 +920,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -888,6 +950,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -916,6 +980,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -944,6 +1010,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -972,6 +1040,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1000,6 +1070,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1028,6 +1100,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1056,6 +1130,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1084,6 +1160,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1112,6 +1190,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1140,6 +1220,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1168,6 +1250,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1196,6 +1280,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1224,6 +1310,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1252,6 +1340,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1280,6 +1370,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1308,6 +1400,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1336,6 +1430,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1364,6 +1460,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1392,6 +1490,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1420,6 +1520,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1448,6 +1550,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1476,6 +1580,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1504,6 +1610,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1532,6 +1640,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1560,6 +1670,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1590,6 +1702,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1620,6 +1734,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1650,6 +1766,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1680,6 +1798,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1710,6 +1830,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1740,6 +1862,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1770,6 +1894,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1800,6 +1926,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1830,6 +1958,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1860,6 +1990,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1890,6 +2022,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1920,6 +2054,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1950,6 +2086,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -1980,6 +2118,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2010,6 +2150,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2040,6 +2182,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2070,6 +2214,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2100,6 +2246,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2130,6 +2278,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2160,6 +2310,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2190,6 +2342,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2220,6 +2374,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2250,6 +2406,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2280,6 +2438,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2310,6 +2470,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2340,6 +2502,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2370,6 +2534,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2400,6 +2566,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2430,6 +2598,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2460,6 +2630,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2490,6 +2662,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2520,6 +2694,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2550,6 +2726,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2580,6 +2758,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2610,6 +2790,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2640,6 +2822,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2670,6 +2854,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2700,6 +2886,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2730,6 +2918,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -2760,6 +2950,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-rf-monitor.yml
+++ b/services/docker-stack-si-rf-monitor.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-rf.yml
+++ b/services/docker-stack-si-rf.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ti-bpms-corrs.yml
+++ b/services/docker-stack-si-ti-bpms-corrs.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ti-general.yml
+++ b/services/docker-stack-si-ti-general.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-si-ti-trims-skews.yml
+++ b/services/docker-stack-si-ti-trims-skews.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-tb-ps-corrs.yml
+++ b/services/docker-stack-tb-ps-corrs.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-tb-ps-dips.yml
+++ b/services/docker-stack-tb-ps-dips.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-tb-ps-quads.yml
+++ b/services/docker-stack-tb-ps-quads.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-tb-ps.yml
+++ b/services/docker-stack-tb-ps.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -48,6 +50,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -76,6 +80,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-tb-ti-general.yml
+++ b/services/docker-stack-tb-ti-general.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-ts-ps-corrs.yml
+++ b/services/docker-stack-ts-ps-corrs.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-ts-ps-dips.yml
+++ b/services/docker-stack-ts-ps-dips.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-ts-ps-quads.yml
+++ b/services/docker-stack-ts-ps-quads.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-ts-ps.yml
+++ b/services/docker-stack-ts-ps.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -48,6 +50,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:
@@ -76,6 +80,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/services/docker-stack-ts-ti-general.yml
+++ b/services/docker-stack-ts-ti-general.yml
@@ -20,6 +20,8 @@ services:
         condition: any
       labels:
         io.portainer.accesscontrol.public: ""
+    labels:
+      br.lnls.logging: ""
     logging:
       driver: "json-file"
       options:

--- a/tools/generate_service_files.py
+++ b/tools/generate_service_files.py
@@ -564,6 +564,8 @@ class DockerStackConfig(ServiceConfig):
         strf += '\n' + '        condition: ' + self.condition
         strf += '\n' + '      labels:'
         strf += '\n' + '        io.portainer.accesscontrol.public: ""'
+        strf += '\n' + '    labels:'
+        strf += '\n' + '      br.lnls.logging: ""'
         strf += '\n' + '    logging:'
         strf += '\n' + '      driver: ' + '"' + self.driver + '"'
         strf += '\n' + '      options:'


### PR DESCRIPTION
Add label used by Grafana Alloy for filtering Docker containers for log forwarding. All services where the label is defined get their logs forwarded to a centralised service, with a web interface for queries.